### PR TITLE
Fix empty set clustering result

### DIFF
--- a/src/Aglomera.Tests/ClusteringTests.cs
+++ b/src/Aglomera.Tests/ClusteringTests.cs
@@ -102,6 +102,19 @@ namespace Aglomera.Tests
         }
 
         [TestMethod]
+        public void EmptyClusteringTest()
+        {
+            foreach (var linkage in Linkages)
+            {
+                Console.WriteLine("________________________");
+                var clusteringResult =
+                    new AgglomerativeClusteringAlgorithm<DataPoint>(linkage).GetClustering(new HashSet<DataPoint>());
+                Console.WriteLine(clusteringResult.Count);
+                Assert.AreEqual(0, clusteringResult.Count, "Empty set should produce an empty clustering result.");
+            }
+        }
+
+        [TestMethod]
         public void ClusterSetsSizeTest()
         {
             foreach (var linkage in Linkages)

--- a/src/Aglomera/AgglomerativeClusteringAlgorithm.cs
+++ b/src/Aglomera/AgglomerativeClusteringAlgorithm.cs
@@ -97,6 +97,12 @@ namespace Aglomera
         {
             // initializes elements
             var currentClusters = clusters.ToArray();
+
+            if (currentClusters.Length == 0)
+            {
+                return new ClusteringResult<TInstance>(0);
+            }
+
             this._clusters = new Cluster<TInstance>[currentClusters.Length * 2 - 1];
             this._dissimilarities = new double[currentClusters.Length * 2 - 1][];
             this._curClusterCount = 0;


### PR DESCRIPTION
When AgglomerativeClusteringAlgorithm.GetClustering receives 0 elements to cluster it throws System.OverflowException because it attempts to create an array of size negative size (-1).